### PR TITLE
Fix Write Response When PRN is enabled

### DIFF
--- a/firmware/app/src/ble.rs
+++ b/firmware/app/src/ble.rs
@@ -98,9 +98,12 @@ impl NrfDfuService {
             NrfDfuServiceEvent::PacketWrite(data) => {
                 let request = DfuRequest::Write { data: &data[..] };
                 return Some(self.process(target, dfu, connection, request, |conn, response| {
-                    if conn.notify_packet {
-                        self.packet_notify(&conn.connection, &Vec::from_slice(response).unwrap())?;
+                    if conn.notify_control {
+                        self.control_notify(&conn.connection, &Vec::from_slice(response).unwrap())?;
                     }
+                    // if conn.notify_packet {
+                    //     self.packet_notify(&conn.connection, &Vec::from_slice(response).unwrap())?;
+                    // }
                     Ok(())
                 }));
             }


### PR DESCRIPTION
According to Nordic Documentation for [SDK v17.x.x](https://infocenter.nordicsemi.com/topic/sdk_nrf5_v17.1.0/lib_dfu_transport_ble.html), despite notification description is enabled for Packet characteristic, but it never used, and all notification responses are sent over Control notification. It is useful when PRN is enabled.
This change is tested.